### PR TITLE
update to assembly-ide-war

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -167,7 +167,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <packagingExcludes>%regex[WEB-INF\\lib\\(?!.*j2ee).*.jar]</packagingExcludes>
                     <overlays>
                         <overlay>
                             <groupId>org.eclipse.che</groupId>


### PR DESCRIPTION
Removed packagingExcludes because this causes maven to, pretty much, not package any of the required libraries in the war file. Maybe the original regex was intended for windows?